### PR TITLE
Update OnRetryFunction type

### DIFF
--- a/src/retry/index.ts
+++ b/src/retry/index.ts
@@ -4,10 +4,13 @@ import { ConfiguredMiddleware, WretcherOptions, Wretcher } from 'wretch'
 
 export type DelayRampFunction = (delay: number, nbOfAttempts: number) => number
 export type UntilFunction = (response?: Response, error?: Error) => boolean | Promise<boolean>
-export type OnRetryFunction = (args: { response?: Response, error?: Error, url: string, options: WretcherOptions }) => ({
-    url?: string,
-    options?: WretcherOptions
-})
+export type OnRetryFunctionResponse = { url?: string; options?: WretcherOptions } | undefined
+export type OnRetryFunction = (args: { 
+    response?: Response, 
+    error?: Error, 
+    url: string, 
+    options: WretcherOptions 
+}) => OnRetryFunctionResponse | Promise<OnRetryFunctionResponse>
 export type RetryOptions = {
     delayTimer?: number,
     delayRamp?: DelayRampFunction,


### PR DESCRIPTION
Two updates to the `OnRetryFunction` type:

- Allow the `onRetry` function to return `void`
  * The return value defaults to an empty object (`values = {}`, on line ~103), so it makes sense that the method should be able to return nothing
- The documentation states that the `onRetry` method supports returning a Promise, but the TypeScript types had not been updated to reflect this