### PR TITLE
Fix lint

### DIFF
--- a/src/throttlingCache/index.ts
+++ b/src/throttlingCache/index.ts
@@ -163,7 +163,7 @@ export const throttlingCache: ThrottlingCacheMiddleware = ({
     }
 
     // Programmatically cache a response
-    middleware['cache'] = function(key, response) {
+    middleware['cache'] = function (key, response) {
         throttleRequest(key)
         cache.set(key, response)
     }


### PR DESCRIPTION
```
❯ yarn lint
yarn run v1.16.0
$ tslint -p tsconfig.json -t codeFrame
/Users/guten/data/dev/source/wretch-middlewares/src/throttlingCache/index.ts
Missing whitespace before function parens (space-before-function-paren)
  164 |
  165 |     // Programmatically cache a response
> 166 |     middleware['cache'] = function(key, response) {
      |                                  ^
  167 |         throttleRequest(key)
  168 |         cache.set(key, response)
  169 |     }


error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```