### PR TITLE
Retry: handle the error edge cases

### DIFF
--- a/src/retry/index.ts
+++ b/src/retry/index.ts
@@ -117,7 +117,7 @@ export const retry: RetryMiddleware = ({
                     }
                 }
 
-                return response
+                return error ? Promise.reject(error) : response
             })
         }
 
@@ -126,7 +126,7 @@ export const retry: RetryMiddleware = ({
             .catch(error => {
                 if(!retryOnNetworkError)
                     throw error
-                checkStatus(null, error)
+                return checkStatus(null, error)
             })
     }
 }

--- a/src/retry/index.ts
+++ b/src/retry/index.ts
@@ -110,7 +110,7 @@ export const retry: RetryMiddleware = ({
                         }).then(checkStatus).catch(error => {
                             if(!retryOnNetworkError)
                                 throw error
-                            checkStatus(null, error)
+                            return checkStatus(null, error)
                         })
                     } else {
                         return Promise.reject(error || new Error('Number of attempts exceeded.'))

--- a/src/retry/index.ts
+++ b/src/retry/index.ts
@@ -113,7 +113,7 @@ export const retry: RetryMiddleware = ({
                             checkStatus(null, error)
                         })
                     } else {
-                        return Promise.reject(new Error('Number of attempts exceeded.'))
+                        return Promise.reject(error || new Error('Number of attempts exceeded.'))
                     }
                 }
 


### PR DESCRIPTION
Fixes

```
TypeError: Cannot read property 'ok' of undefined
    at /Users/guten/data/dev/learn/node_modules/wretch/dist/bundle/wretch.js:1:4803
    at processTicksAndRejections (internal/process/task_queues.js:82:5)
```

to the [source](https://github.com/elbywan/wretch/blob/master/src/resolver.ts#L62)


To reproduce

```js
const { retry } = require('wretch-middlewares')
wretch().url(url).middlewares([
  retry({
    retryOnNetworkError: true,
  }),
  next => (url, options) => {
    // custom api error, simplified for demo purpose
    throw new Error('foo')
  }
]).get().json()
```

Because

[line-120](https://github.com/elbywan/wretch-middlewares/compare/master...gutenye:retry-error?expand=1#diff-e890b7886bda49f9befb953e6d08b547L120) miss one case when `checkStatus(null, error)` is called and `done is false`